### PR TITLE
Add support for international strings

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -138,7 +138,7 @@ func initTimerBasedTest(settings TimerBasedTestSettings) TimerBasedTest {
 			timedout:  false,
 		},
 		base: TestBase{
-			wordsToEnter: NewGenerator().Generate(settings.wordListSelections[settings.wordListCursor].key),
+			wordsToEnter: []rune(NewGenerator().Generate(settings.wordListSelections[settings.wordListCursor].key)),
 			inputBuffer:  make([]rune, 0),
 			rawInputCnt:  0,
 			mistakes: mistakes{
@@ -161,7 +161,7 @@ func initWordCountBasedTest(settings WordCountBasedTestSettings) WordCountBasedT
 			isRunning: false,
 		},
 		base: TestBase{
-			wordsToEnter: strings.TrimSpace(generator.Generate(settings.wordListSelections[settings.wordListCursor].key)),
+			wordsToEnter: []rune(strings.TrimSpace(generator.Generate(settings.wordListSelections[settings.wordListCursor].key))),
 			inputBuffer:  make([]rune, 0),
 			rawInputCnt:  0,
 			mistakes: mistakes{
@@ -185,7 +185,7 @@ func initSentenceCountBasedTest(settings SentenceCountBasedTestSettings) Sentenc
 			isRunning: false,
 		},
 		base: TestBase{
-			wordsToEnter: strings.TrimSpace(generator.Generate(settings.sentenceListSelections[settings.sentenceListCursor].key)),
+			wordsToEnter: []rune(strings.TrimSpace(generator.Generate(settings.sentenceListSelections[settings.sentenceListCursor].key))),
 			inputBuffer:  make([]rune, 0),
 			rawInputCnt:  0,
 			mistakes: mistakes{

--- a/src/model.go
+++ b/src/model.go
@@ -97,7 +97,7 @@ type MainMenu struct {
 }
 
 type TestBase struct {
-	wordsToEnter string
+	wordsToEnter []rune
 	inputBuffer  []rune
 	rawInputCnt  int // Should not be reduced
 	mistakes     mistakes

--- a/src/update.go
+++ b/src/update.go
@@ -495,7 +495,7 @@ func (base TestBase) handleRunes(msg tea.KeyMsg) TestBase {
 	letterToInput := base.wordsToEnter[inputLenDec:inputLen]
 	inputLetter := string(base.inputBuffer[inputLenDec:])
 
-	if letterToInput != inputLetter {
+	if string(letterToInput) != inputLetter {
 		base.mistakes.mistakesAt[inputLenDec] = true
 		base.mistakes.rawMistakesCnt = base.mistakes.rawMistakesCnt + 1
 	}
@@ -532,7 +532,7 @@ func (base TestBase) handleSpace() TestBase {
 	return base
 }
 
-func findNextSpaceIndex(wordsToInput string, cursorAt int) int {
+func findNextSpaceIndex(wordsToInput []rune, cursorAt int) int {
 	trimmedWordsToInput := wordsToInput[cursorAt:]
 	words := []rune(trimmedWordsToInput)
 
@@ -548,7 +548,7 @@ func findNextSpaceIndex(wordsToInput string, cursorAt int) int {
 }
 
 func (base TestBase) findLatestWsIndex() int {
-	return findLatestWsIndex(base.wordsToEnter, base.cursor)
+	return findLatestWsIndex(string(base.wordsToEnter), base.cursor)
 }
 
 func findLatestWsIndex(wordsToInput string, cursorAt int) int {

--- a/src/view.go
+++ b/src/view.go
@@ -289,7 +289,7 @@ func (base TestBase) colorInput(styles Styles) string {
 			mistakeSlice := base.wordsToEnter[mistakeAt : mistakeAt+1]
 
 			coloredInput += styleAllRunes(sliceUntilMistake, styles.correct)
-			coloredInput += style(mistakeSlice, styles.mistakes)
+			coloredInput += style(string(mistakeSlice), styles.mistakes)
 
 			previousMistake = mistakeAt
 		}
@@ -304,13 +304,13 @@ func (base TestBase) colorInput(styles Styles) string {
 func (base TestBase) colorCursor(styles Styles) string {
 	cursorLetter := base.wordsToEnter[len(base.inputBuffer) : len(base.inputBuffer)+1]
 
-	return style(cursorLetter, styles.cursor)
+	return style(string(cursorLetter), styles.cursor)
 }
 
 func (base TestBase) colorWordsToEnter(styles Styles) string {
 	wordsToEnter := base.wordsToEnter[len(base.inputBuffer)+1:] // without cursor
 
-	return style(wordsToEnter, styles.toEnter)
+	return style(string(wordsToEnter), styles.toEnter)
 }
 
 func wrapStyledParagraph(paragraph string, lineLimit int) string {


### PR DESCRIPTION
Hi!
Thank you for great typing test. Terminal is much better place for me then online services. Great work!

I would like to use other languages to type in, but there is problem with characters created by more then one byte.

This PR solves that. When we use []rune everywhere where we work with index it solves problem.

If you want to test current problems or this fix overwrite file `src/embedables/words/common-english.txt` with this content for example:
```
cześć
łżóń
śruba
żółć
kość
```
There is currently another small bug, related to generating lists of words (I will send another PR in minute ;-)), so ignore "empty word" bug.