### PR TITLE
Use []rune for `wordsToInput` in more places

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"os"
 	"os/signal"
-	"strings"
 	"syscall"
 	"time"
 
@@ -138,7 +137,7 @@ func initTimerBasedTest(settings TimerBasedTestSettings) TimerBasedTest {
 			timedout:  false,
 		},
 		base: TestBase{
-			wordsToEnter: []rune(NewGenerator().Generate(settings.wordListSelections[settings.wordListCursor].key)),
+			wordsToEnter: NewGenerator().Generate(settings.wordListSelections[settings.wordListCursor].key),
 			inputBuffer:  make([]rune, 0),
 			rawInputCnt:  0,
 			mistakes: mistakes{
@@ -161,7 +160,7 @@ func initWordCountBasedTest(settings WordCountBasedTestSettings) WordCountBasedT
 			isRunning: false,
 		},
 		base: TestBase{
-			wordsToEnter: []rune(strings.TrimSpace(generator.Generate(settings.wordListSelections[settings.wordListCursor].key))),
+			wordsToEnter: generator.Generate(settings.wordListSelections[settings.wordListCursor].key),
 			inputBuffer:  make([]rune, 0),
 			rawInputCnt:  0,
 			mistakes: mistakes{
@@ -185,7 +184,7 @@ func initSentenceCountBasedTest(settings SentenceCountBasedTestSettings) Sentenc
 			isRunning: false,
 		},
 		base: TestBase{
-			wordsToEnter: []rune(strings.TrimSpace(generator.Generate(settings.sentenceListSelections[settings.sentenceListCursor].key))),
+			wordsToEnter: generator.Generate(settings.sentenceListSelections[settings.sentenceListCursor].key),
 			inputBuffer:  make([]rune, 0),
 			rawInputCnt:  0,
 			mistakes: mistakes{

--- a/src/update.go
+++ b/src/update.go
@@ -492,10 +492,10 @@ func (base TestBase) handleRunes(msg tea.KeyMsg) TestBase {
 	inputLen := len(base.inputBuffer)
 	inputLenDec := inputLen - 1
 
-	letterToInput := base.wordsToEnter[inputLenDec:inputLen]
-	inputLetter := string(base.inputBuffer[inputLenDec:])
+	letterToInput := base.wordsToEnter[inputLenDec]
+	inputLetter := base.inputBuffer[inputLenDec]
 
-	if string(letterToInput) != inputLetter {
+	if letterToInput != inputLetter {
 		base.mistakes.mistakesAt[inputLenDec] = true
 		base.mistakes.rawMistakesCnt = base.mistakes.rawMistakesCnt + 1
 	}
@@ -534,7 +534,7 @@ func (base TestBase) handleSpace() TestBase {
 
 func findNextSpaceIndex(wordsToInput []rune, cursorAt int) int {
 	trimmedWordsToInput := wordsToInput[cursorAt:]
-	words := []rune(trimmedWordsToInput)
+	words := trimmedWordsToInput
 
 	var wsIdx int = 0
 	for idx, value := range words {
@@ -548,11 +548,14 @@ func findNextSpaceIndex(wordsToInput []rune, cursorAt int) int {
 }
 
 func (base TestBase) findLatestWsIndex() int {
-	return findLatestWsIndex(string(base.wordsToEnter), base.cursor)
+	return findLatestWsIndex(base.wordsToEnter, base.cursor)
 }
 
-func findLatestWsIndex(wordsToInput string, cursorAt int) int {
-	trimmedWordsToInput := wordsToInput[:cursorAt]
+func findLatestWsIndex(wordsToInput []rune, cursorAt int) int {
+	var wordsToInputCopy []rune
+	copy(wordsToInputCopy, wordsToInput)
+
+	trimmedWordsToInput := wordsToInputCopy[:cursorAt]
 	reversed := reverse([]rune(trimmedWordsToInput))
 
 	var wsIdx int = 0

--- a/src/util.go
+++ b/src/util.go
@@ -9,7 +9,7 @@ func averageStringLen(strings []string) int {
 	var cnt int = 0
 
 	for _, str := range strings {
-		currentLen := len(dropAnsiCodes(str))
+		currentLen := len([]rune(dropAnsiCodes(str)))
 		totalLen += currentLen
 		cnt += 1
 	}

--- a/src/words.go
+++ b/src/words.go
@@ -65,7 +65,7 @@ func NewGenerator() (g WordsGenerator) {
 	return g
 }
 
-func (this WordsGenerator) Generate(poolKey string) string {
+func (this WordsGenerator) Generate(poolKey string) []rune {
 	pool := makePool(this.pools[poolKey])
 	acc := []string{}
 	poolLength := len(pool)
@@ -75,5 +75,5 @@ func (this WordsGenerator) Generate(poolKey string) string {
 		acc = append(acc, word)
 	}
 
-	return strings.Join(acc, " ")
+	return []rune(strings.TrimSpace(strings.Join(acc, " ")))
 }


### PR DESCRIPTION
This avoids allocating new string values in several places