### PR TITLE
Fix word generator taking empty words

### DIFF
--- a/src/words.go
+++ b/src/words.go
@@ -70,9 +70,11 @@ func (this WordsGenerator) Generate(poolKey string) []rune {
 	acc := []string{}
 	poolLength := len(pool)
 	for i := 0; i < this.Count; i++ {
-		word := pool[rand.Int()%(poolLength-1)]
+		word := pool[rand.Int()%poolLength]
 		word = regexp.MustCompile("\r|\n").ReplaceAllString(word, "")
-		acc = append(acc, word)
+		if word != "" {
+			acc = append(acc, word)
+		}
 	}
 
 	return []rune(strings.TrimSpace(strings.Join(acc, " ")))


### PR DESCRIPTION
Previous fix we had merely ignored the last line from word list (which
is commonly is some kind of whitespace, usually newline). But for word
lists generated with Clojure scripts, it effectively ignored the last
word, which is not ideal.

This fixes that by checking whether the word we are pulling in is not
empty.