### PR TITLE
Separate build and release jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,13 @@ on:
   push:
     tags:
       - "*"
+    branches:
+      - master
+  pull_request:
+    branches: [master]
 
 jobs:
-  build-and-release:
+  build:
     runs-on: ubuntu-latest
 
     steps:
@@ -42,13 +46,19 @@ jobs:
           name: typioca-mac-arm64
           path: execs/typioca-mac-arm64
 
-      # Release
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          path: execs
       - id: get_version
         uses: battila7/get-version-action@v2
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
       - name: Release
         uses: softprops/action-gh-release@v1
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
         with:
           name: typioca ${{ steps.get_version.outputs.version }}
-          files: execs/*
+          files: execs/**/*


### PR DESCRIPTION
https://github.com/bloznelis/typioca/pull/53#issuecomment-1170879182, build and release jobs are now separated from each other and not mixed together:
![image](https://user-images.githubusercontent.com/56180050/176630734-9c62670b-f457-4532-a017-96685581308d.png)
![image](https://user-images.githubusercontent.com/56180050/176631441-9c08dc67-0bde-485e-9426-ab2ad7c16645.png)
