### PR TITLE
Add scoop installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,12 @@ Minimal, terminal based typing speed tester.
 
 ## Installation
 
-### Windows
+### Homebrew
 
-#### Scoop
-
+For Linux and macOS users:
 ```
-scoop bucket add extras
-scoop install typioca
+brew tap bloznelis/tap
+brew install typioca
 ```
 
 ### Linux
@@ -40,12 +39,13 @@ scoop install typioca
 yay -S typioca-git
 ```
 
-### Homebrew
+### Windows
 
-For Linux and macOS users:
+#### Scoop
+
 ```
-brew tap bloznelis/tap
-brew install typioca
+scoop bucket add extras
+scoop install typioca
 ```
 
 ### Go

--- a/README.md
+++ b/README.md
@@ -23,24 +23,10 @@ Minimal, terminal based typing speed tester.
 
 ## Installation
 
-### Homebrew
-
-```
-brew tap bloznelis/tap
-brew install typioca
-```
-
 ### AUR
 
 ```
 yay -S typioca-git
-```
-
-### Scoop
-
-```
-scoop bucket add extras
-scoop install typioca
 ```
 
 ### Go
@@ -49,7 +35,19 @@ scoop install typioca
 go install github.com/bloznelis/typioca@latest
 ```
 
-**Note:** This will install typioca in `$GOBIN`, which defaults to `$GOPATH/bin` or `$HOME/go/bin` if the GOPATH environment variable is not set.
+### Homebrew
+
+```
+brew tap bloznelis/tap
+brew install typioca
+```
+
+### Scoop
+
+```
+scoop bucket add extras
+scoop install typioca
+```
 
 ### Building from source
   1. Checkout the code

--- a/README.md
+++ b/README.md
@@ -40,10 +40,9 @@ scoop install typioca
 yay -S typioca-git
 ```
 
-### macOS
+### Homebrew
 
-#### Homebrew
-
+For Linux and macOS users:
 ```
 brew tap bloznelis/tap
 brew install typioca

--- a/README.md
+++ b/README.md
@@ -20,17 +20,40 @@ Minimal, terminal based typing speed tester.
   * Dynamic word lists
   * Custom word lists
   * Linux/Mac/Win support
-  
-## Installation
-### AUR
-`yay -S typioca-git`
 
-### Homebrew
-1. `brew tap bloznelis/tap`
-2. `brew install typioca`
+## Installation
+
+### Windows
+
+#### Scoop
+
+```
+scoop bucket add extras
+scoop install typioca
+```
+
+### Linux
+
+#### AUR
+
+```
+yay -S typioca-git
+```
+
+### macOS
+
+#### Homebrew
+
+```
+brew tap bloznelis/tap
+brew install typioca
+```
 
 ### Go
-`go install github.com/bloznelis/typioca@latest`
+
+```
+go install github.com/bloznelis/typioca@latest
+```
 
 **Note:** This will install typioca in `$GOBIN`, which defaults to `$GOPATH/bin` or `$HOME/go/bin` if the GOPATH environment variable is not set.
 

--- a/README.md
+++ b/README.md
@@ -25,23 +25,18 @@ Minimal, terminal based typing speed tester.
 
 ### Homebrew
 
-For Linux and macOS users:
 ```
 brew tap bloznelis/tap
 brew install typioca
 ```
 
-### Linux
-
-#### AUR
+### AUR
 
 ```
 yay -S typioca-git
 ```
 
-### Windows
-
-#### Scoop
+### Scoop
 
 ```
 scoop bucket add extras

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ yay -S typioca-git
 go install github.com/bloznelis/typioca@latest
 ```
 
+**Note:** This will install typioca in `$GOBIN`, which defaults to `$GOPATH/bin` or `$HOME/go/bin` if the GOPATH environment variable is not set.
+
 ### Homebrew
 
 ```


### PR DESCRIPTION
Adding a reference here as I just added [`typioca`](https://github.com/ScoopInstaller/Extras/blob/master/bucket/typioca.json) to Scoop. Also categorized the package managers via OS (Windows, Linux, and macOS) for organization.