### PR TITLE
Add Winget Releaser workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,4 +70,4 @@ jobs:
         with:
           identifier: bloznelis.typioca
           version: ${{ github.ref_name }}
-          token: ${{ secrets.WINGET_TOKEN }}
+          token: ${{ secrets.PUBLIC_REPO_ACCESS }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,3 +62,12 @@ jobs:
         with:
           name: typioca ${{ steps.get_version.outputs.version }}
           files: execs/**/*
+  winget:
+    needs: release
+    runs-on: windows-latest # Action can only be run on Windows
+    steps:
+      - uses: vedantmgoyal2009/winget-releaser@v1
+        with:
+          identifier: bloznelis.typioca
+          version: ${{ github.ref_name }}
+          token: ${{ secrets.WINGET_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ scoop bucket add extras
 scoop install typioca
 ```
 
+### Winget
+
+```
+winget install bloznelis.typioca
+```
+
 ### Building from source
   1. Checkout the code
   2. `make build`


### PR DESCRIPTION
This action automatically generates manifests for the Winget Community Repository ([microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs)).

I have just added typioca to Winget (https://github.com/microsoft/winget-pkgs/pull/94813). This workflow would enable automatic package updates for it.

**Before merging this:**
1. Add a PAT with `public_repo` scope as a repository secret named `WINGET_TOKEN`.

![example](https://user-images.githubusercontent.com/56180050/180631504-f19d12cc-19ce-4991-a753-d4f7ff0adbca.png)

2. Fork https://github.com/microsoft/winget-pkgs under @bloznelis. The action will use that fork for making a branch and creating a PR with the upstream [winget-pkgs](https://github.com/microsoft/winget-pkgs) repository on every release.
3. Install [Pull](https://github.com/apps/pull) on the winget-pkgs fork to ensure that it is constantly updated.

The documentation and source code of the action is available [here](https://github.com/vedantmgoyal2009/winget-releaser/).

If you want to see an example of a PR created using this action, see [microsoft/winget-pkgs/pulls (Pull request has been automatically created using 🛫 WinGet Releaser)](https://github.com/microsoft/winget-pkgs/pulls?q=is%3Apr+sort%3Aupdated-desc+Pull+request+has+been+automatically+created+using+%F0%9F%9B%AB+WinGet+Releaser).