### PR TITLE
Bump Winget Releaser to v2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "daily"
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
     needs: release
     runs-on: windows-latest # Action can only be run on Windows
     steps:
-      - uses: vedantmgoyal2009/winget-releaser@v1
+      - uses: vedantmgoyal2009/winget-releaser@v2
         with:
           identifier: bloznelis.typioca
           version: ${{ github.ref_name }}


### PR DESCRIPTION
Fix recent Winget Releaser error. I expected Dependabot to bump this, but the interval length is too slow. I have changed the `github-actions` interval to daily.