### PR TITLE
feat: Add persistent results

### DIFF
--- a/cmd/model.go
+++ b/cmd/model.go
@@ -48,12 +48,35 @@ type model struct {
 }
 
 type Results struct {
+  identifier ResultsIdentifier
 	wpm      int
 	accuracy float64
+  deltaWpm float64
 	rawWpm   int
 	cpm      int
 	time     time.Duration
 	wordList string
+	wpmEachSecond []float64
+}
+
+type PersistentResults struct {
+  Results AllPersistedResults
+  Version int
+}
+
+type ResultsIdentifier struct {
+  testType TestType
+  numeric NumericSetting
+  words WordListName
+}
+
+type PersistentResultsNode struct {
+	Wpm      int
+	Accuracy float64
+  DeltaWpm float64
+	RawWpm   int
+	Cpm      int
+	WpmEachSecond []float64
 }
 
 type WordListSelection struct {

--- a/cmd/results-io.go
+++ b/cmd/results-io.go
@@ -1,0 +1,120 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"github.com/bloznelis/typioca/cmd/words"
+)
+
+type TestType = string
+type NumericSetting = int
+type WordListName = string
+type AllPersistedResults = map[TestType]map[NumericSetting]map[WordListName][]PersistentResultsNode
+
+func PersistResults(results Results) PersistentResults{
+  var resultsFile = getResultsPath()
+  var persistentResults PersistentResults
+
+	//File does not exist?
+	if _, err := os.Stat(resultsFile); os.IsNotExist(err) {
+    persistentResults = defaultPersistentResults()
+	} else {
+    readResults(&persistentResults)
+    // XXX: Once needed, version check should happen here
+	}
+
+  persistentResults.addResults(results)
+
+  writeResults(persistentResults)
+
+  return persistentResults
+}
+
+func defaultPersistentResults() PersistentResults {
+  return PersistentResults {
+    Results: AllPersistedResults{},
+    Version: 1,
+  }
+}
+
+func ReadResults(i ResultsIdentifier) []PersistentResultsNode {
+  var resultsFile = getResultsPath()
+  var persistentResults PersistentResults
+
+	//File does not exist?
+	if _, err := os.Stat(resultsFile); os.IsNotExist(err) {
+    persistentResults = defaultPersistentResults()
+	} else {
+    readResults(&persistentResults)
+    // XXX: Once needed, version check should happen here
+	}
+  var res = persistentResults.Results[i.testType][i.numeric][i.words]
+  if res == nil {
+    return make([]PersistentResultsNode, 0)
+  }
+  return res
+}
+
+func readResults(results *PersistentResults) {
+  var resultsFilePath = getResultsPath()
+	fh, err := os.Open(resultsFilePath)
+	if err != nil {
+		panic(err)
+	}
+	defer fh.Close()
+
+	decoder := json.NewDecoder(fh)
+	decoder.Decode(results)
+}
+
+func (p *PersistentResults) addResults(results Results) {
+  var limit = 25 // XXX: Should be configurable eventually
+
+  var node = PersistentResultsNode {
+    Wpm: results.wpm,
+    Accuracy: results.accuracy,
+    DeltaWpm: results.deltaWpm,
+    RawWpm: results.rawWpm,
+    Cpm: results.cpm,
+    WpmEachSecond: results.wpmEachSecond,
+  }
+  var i = results.identifier
+
+  if p.Results[i.testType] == nil {
+    p.Results[i.testType] = map[NumericSetting]map[WordListName][]PersistentResultsNode{}
+  }
+
+  if p.Results[i.testType][i.numeric] == nil {
+    p.Results[i.testType][i.numeric] = map[WordListName][]PersistentResultsNode{}
+  }
+
+  var nodes = append(p.Results[i.testType][i.numeric][i.words], node)
+
+  if len(nodes) > limit {
+    nodes = nodes[len(nodes)-limit:]
+  }
+
+  p.Results[i.testType][i.numeric][i.words] = nodes
+}
+
+func writeResults(results PersistentResults) {
+  var resultsFilePath = getResultsPath()
+	words.EnsureDir(resultsFilePath)
+	fh, err := os.Create(resultsFilePath)
+	if err != nil {
+		panic(err)
+	}
+	defer fh.Close()
+
+  encoder := json.NewEncoder(fh)
+  encoder.SetIndent("", "\t")
+  encoder.Encode(results)
+}
+
+func getResultsPath() string {
+  var cachePath = getCachePath()
+  var resultsFilePath = filepath.Join(cachePath, "results.json")
+  return resultsFilePath
+}

--- a/cmd/results.go
+++ b/cmd/results.go
@@ -6,39 +6,100 @@ import (
 )
 
 func (m TimerBasedTest) calculateResults() Results {
+	wordlist := m.settings.wordListSelections[m.settings.wordListCursor].name
+	identifier := ResultsIdentifier{
+		testType: "TimerBasedTest",
+		numeric:  int(m.timer.duration),
+		words:    wordlist,
+	}
+
 	elapsedMinutes := m.timer.duration.Minutes()
+	wpm := m.base.calculateNormalizedWpm(elapsedMinutes)
+	deltaWpm := calculateAverageWpmDeltaPercentage(wpm, ReadResults(identifier))
+
 	return Results{
-		wpm:      int(m.base.calculateNormalizedWpm(elapsedMinutes)),
-		accuracy: m.base.calculateAccuracy(),
-		rawWpm:   int(m.base.calculateRawWpm(elapsedMinutes)),
-		cpm:      m.base.calculateCpm(elapsedMinutes),
-		time:     m.timer.duration,
-		wordList: m.settings.wordListSelections[m.settings.wordListCursor].name,
+		identifier: identifier,
+		wpm:        int(wpm),
+		accuracy:   m.base.calculateAccuracy(),
+		deltaWpm:   deltaWpm,
+		rawWpm:     int(m.base.calculateRawWpm(elapsedMinutes)),
+		cpm:        m.base.calculateCpm(elapsedMinutes),
+		time:       m.timer.duration,
+		wordList:   wordlist,
+    wpmEachSecond: m.base.wpmEachSecond,
 	}
 }
 
 func (m WordCountBasedTest) calculateResults() Results {
+	count := m.settings.wordCountSelections[m.settings.wordCountCursor]
+	wordlist := m.settings.wordListSelections[m.settings.wordListCursor].name
+
+	identifier := ResultsIdentifier{
+		testType: "WordCountBasedTest",
+		numeric:  count,
+		words:    wordlist,
+	}
+
 	elapsedMinutes := m.stopwatch.stopwatch.Elapsed().Minutes()
+	wpm := m.base.calculateNormalizedWpm(elapsedMinutes)
+	deltaWpm := calculateAverageWpmDeltaPercentage(wpm, ReadResults(identifier))
+
 	return Results{
-		wpm:      int(m.base.calculateNormalizedWpm(elapsedMinutes)),
-		accuracy: m.base.calculateAccuracy(),
-		rawWpm:   int(m.base.calculateRawWpm(elapsedMinutes)),
-		cpm:      m.base.calculateCpm(elapsedMinutes),
-		time:     m.stopwatch.stopwatch.Elapsed(),
-		wordList: m.settings.wordListSelections[m.settings.wordListCursor].name,
+		identifier: identifier,
+		wpm:        int(wpm),
+		accuracy:   m.base.calculateAccuracy(),
+		deltaWpm:   deltaWpm,
+		rawWpm:     int(m.base.calculateRawWpm(elapsedMinutes)),
+		cpm:        m.base.calculateCpm(elapsedMinutes),
+		time:       m.stopwatch.stopwatch.Elapsed(),
+		wordList:   wordlist,
+    wpmEachSecond: m.base.wpmEachSecond,
 	}
 }
 
 func (m SentenceCountBasedTest) calculateResults() Results {
-	elapsedMinutes := m.stopwatch.stopwatch.Elapsed().Minutes()
-	return Results{
-		wpm:      int(m.base.calculateNormalizedWpm(elapsedMinutes)),
-		accuracy: m.base.calculateAccuracy(),
-		rawWpm:   int(m.base.calculateRawWpm(elapsedMinutes)),
-		cpm:      m.base.calculateCpm(elapsedMinutes),
-		time:     m.stopwatch.stopwatch.Elapsed(),
-		wordList: m.settings.sentenceListSelections[m.settings.sentenceListCursor].name,
+	count := m.settings.sentenceCountSelections[m.settings.sentenceCountCursor]
+	wordlist := m.settings.sentenceListSelections[m.settings.sentenceListCursor].name
+
+	identifier := ResultsIdentifier{
+		testType: "SentenceCountBasedTest",
+		numeric:  count,
+		words:    wordlist,
 	}
+
+	elapsedMinutes := m.stopwatch.stopwatch.Elapsed().Minutes()
+	wpm := m.base.calculateNormalizedWpm(elapsedMinutes)
+	deltaWpm := calculateAverageWpmDeltaPercentage(wpm, ReadResults(identifier))
+
+	return Results{
+		identifier: identifier,
+		wpm:        int(wpm),
+		accuracy:   m.base.calculateAccuracy(),
+		deltaWpm:   deltaWpm,
+		rawWpm:     int(m.base.calculateRawWpm(elapsedMinutes)),
+		cpm:        m.base.calculateCpm(elapsedMinutes),
+		time:       m.stopwatch.stopwatch.Elapsed(),
+		wordList:   wordlist,
+    wpmEachSecond: m.base.wpmEachSecond,
+	}
+}
+
+func calculateAverageWpmDeltaPercentage(wpm float64, previousResults []PersistentResultsNode) float64 {
+	previousAvg := calcPreviousResultsAvgWpm(previousResults)
+
+	return ((wpm - previousAvg) / math.Max(1.0, previousAvg)) * 100
+}
+
+func calcPreviousResultsAvgWpm(previousResults []PersistentResultsNode) float64 {
+  if len(previousResults) == 0 {
+    return 0
+  }
+	var sum int
+	for _, v := range previousResults {
+		sum += v.Wpm
+	}
+
+	return float64(sum) / float64(len(previousResults))
 }
 
 func (base TestBase) calculateNormalizedWpm(elapsedMinutes float64) float64 {

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -75,10 +75,15 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if state.timer.timer.Timedout() {
 				termenv.Reset() // get rid of faintness
 				state.timer.timedout = true
+
+        var results = state.calculateResults()
+
+        PersistResults(results)
+
 				m.state = TimerBasedTestResults{
 					settings:      state.settings,
 					wpmEachSecond: state.base.wpmEachSecond,
-					results:       state.calculateResults(),
+					results:       results,
 					mainMenu:      state.mainMenu,
 				}
 			}
@@ -184,11 +189,16 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Finished?
 		if len(state.base.wordsToEnter) == len(state.base.inputBuffer) {
 			termenv.Reset() // get rid of faintness
+
+      var results = state.calculateResults()
+
+      PersistResults(results)
+
 			m.state = WordCountTestResults{
 				settings:      state.settings,
 				wpmEachSecond: state.base.wpmEachSecond,
 				wordCnt:       state.settings.wordCountSelections[state.settings.wordCountCursor],
-				results:       state.calculateResults(),
+				results:       results,
 				mainMenu:      state.mainMenu,
 			}
 		}
@@ -253,14 +263,19 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 
-		//Finished?
+		// Finished?
 		if len(state.base.wordsToEnter) == len(state.base.inputBuffer) {
 			termenv.Reset() // get rid of faintness
+
+      var results = state.calculateResults()
+
+      PersistResults(results)
+
 			m.state = SentenceCountTestResults{
 				settings:      state.settings,
 				wpmEachSecond: state.base.wpmEachSecond,
 				sentenceCnt:   state.settings.sentenceCountSelections[state.settings.sentenceCountCursor],
-				results:       state.calculateResults(),
+				results:       results,
 				mainMenu:      state.mainMenu,
 			}
 		}

--- a/cmd/view.go
+++ b/cmd/view.go
@@ -148,13 +148,13 @@ func (m model) View() string {
 
 	case TimerBasedTestResults:
 		rawWpmShow := "raw: " + style(strconv.Itoa(state.results.rawWpm), m.styles.greener)
-		cpm := "cpm: " + style(strconv.Itoa(state.results.cpm), m.styles.greener)
 		wpm := "wpm: " + style(strconv.Itoa(state.results.wpm), m.styles.runningTimer)
+    deltaWpm := "Δavg: " + style(fmt.Sprintf("%s%.2f%%", plusIfPositive(state.results.deltaWpm), math.Min(state.results.deltaWpm, 100.0)), m.styles.greener)
 		givenTime := "time: " + style(state.results.time.String(), m.styles.greener)
 		accuracy := "accuracy: " + style(fmt.Sprintf("%.1f", state.results.accuracy), m.styles.greener)
 		words := "words: " + style(state.results.wordList, m.styles.greener)
 
-		miscStatsLine1 := accuracy + " " + rawWpmShow + " " + cpm + " " + givenTime
+		miscStatsLine1 := fmt.Sprintf("%s %s %s %s", accuracy, deltaWpm, rawWpmShow, givenTime)
 		miscStatsLine2 := words
 
 		miscStatsLine1Len := len(dropAnsiCodes(miscStatsLine1))
@@ -166,14 +166,15 @@ func (m model) View() string {
 
 	case WordCountTestResults:
 		rawWpmShow := "raw: " + style(strconv.Itoa(state.results.rawWpm), m.styles.greener)
-		cpm := "cpm: " + style(strconv.Itoa(state.results.cpm), m.styles.greener)
+		//cpm := "cpm: " + style(strconv.Itoa(state.results.cpm), m.styles.greener)
 		wpm := "wpm: " + style(strconv.Itoa(state.results.wpm), m.styles.runningTimer)
+    deltaWpm := "Δavg: " + style(fmt.Sprintf("%s%.2f%%", plusIfPositive(state.results.deltaWpm), math.Min(state.results.deltaWpm, 100.0)), m.styles.greener)
 		givenTime := "time: " + style(state.results.time.String(), m.styles.greener)
 		wordCnt := "cnt: " + style(strconv.Itoa(state.wordCnt), m.styles.greener)
 		accuracy := "accuracy: " + style(fmt.Sprintf("%.1f", state.results.accuracy), m.styles.greener)
 		words := "words: " + style(state.results.wordList, m.styles.greener)
 
-		miscStatsLine1 := accuracy + " " + rawWpmShow + " " + cpm + " " + givenTime
+		miscStatsLine1 := fmt.Sprintf("%s %s %s %s", accuracy, deltaWpm, rawWpmShow, givenTime)
 		miscStatsLine2 := wordCnt + " " + words
 
 		miscStatsLine1Len := len(dropAnsiCodes(miscStatsLine1))
@@ -186,14 +187,15 @@ func (m model) View() string {
 
 	case SentenceCountTestResults:
 		rawWpmShow := "raw: " + style(strconv.Itoa(state.results.rawWpm), m.styles.greener)
-		cpm := "cpm: " + style(strconv.Itoa(state.results.cpm), m.styles.greener)
+		//cpm := "cpm: " + style(strconv.Itoa(state.results.cpm), m.styles.greener)
 		wpm := "wpm: " + style(strconv.Itoa(state.results.wpm), m.styles.runningTimer)
+    deltaWpm := "Δavg: " + style(fmt.Sprintf("%s%.2f%%", plusIfPositive(state.results.deltaWpm), math.Min(state.results.deltaWpm, 100.0)), m.styles.greener)
 		givenTime := "time: " + style(state.results.time.String(), m.styles.greener)
 		sentenceCnt := "cnt: " + style(strconv.Itoa(state.sentenceCnt), m.styles.greener)
 		accuracy := "accuracy: " + style(fmt.Sprintf("%.1f", state.results.accuracy), m.styles.greener)
 		words := "sentences: " + style(state.results.wordList, m.styles.greener)
 
-		miscStatsLine1 := accuracy + " " + rawWpmShow + " " + cpm + " " + givenTime
+		miscStatsLine1 := fmt.Sprintf("%s %s %s %s", accuracy, deltaWpm, rawWpmShow, givenTime)
 		miscStatsLine2 := sentenceCnt + " " + words
 
 		miscStatsLine1Len := len(dropAnsiCodes(miscStatsLine1))
@@ -281,6 +283,14 @@ func (m model) View() string {
 	}
 
 	return s
+}
+
+func plusIfPositive(f float64) string {
+  if f > 0.0 {
+    return "+"
+  } else {
+    return ""
+  }
 }
 
 func positionVerticaly(termHeight int) string {


### PR DESCRIPTION
This lays the groundwork needed by to https://github.com/bloznelis/typioca/issues/66. What's left is just a nice UI for historical results management.

---

**Changelog:**

* Add: results persistency
* Add: delta percentage from average wpm statistic in the results view
![image](https://github.com/bloznelis/typioca/assets/33397865/557d76ee-163f-4a40-8e32-b425684b323b)
