### PR TITLE
Update Winget job runner to `ubuntu-latest`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
           files: execs/**/*
   winget:
     needs: release
-    runs-on: windows-latest # Action can only be run on Windows
+    runs-on: ubuntu-latest
     steps:
       - uses: vedantmgoyal2009/winget-releaser@v2
         with:


### PR DESCRIPTION
Winget Releaser now supports non-Windows runners.