### PR TITLE
Added x install Support for typioca

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ xbps-install typioca
 winget install bloznelis.typioca
 ```
 
+### X-CMD
+
+```
+x install typioca
+```
+
 ### Building from source
   1. Checkout the code
   2. `make build`


### PR DESCRIPTION
Hi there,

I've updated the README to include x install from the x-cmd ecosystem, making typioca installation easier across different platforms and package managers.

I've also created an introduction page:
👉 https://x-cmd.com/install/typioca

Hope this helps! Let me know if any changes are needed.

Thanks!